### PR TITLE
ディレクトリチェックを追加

### DIFF
--- a/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
+++ b/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
@@ -25,6 +25,11 @@ module Fastlane
         devices = Dir.chdir("#{screenshot_dir}") do
           Dir.glob("*").select { |path| FileTest.directory? path }.sort
         end
+        if devices.empty?
+          UI.message("That screenshot dir is empty")
+          return
+        end
+
         header = "<tr><td>Screen Name</td>\n#{devices.map { |device| "<td>#{device}</td>\n" }.inject(&:+)}</tr>"
         rows = Dir.glob("#{screenshot_dir}/#{devices[0]}/*.jpg")
                    .map { |path| File.basename(path) }
@@ -52,8 +57,7 @@ module Fastlane
                        "<td><img src=\"#{url}\" #{size_attr}/></td>\n"
                      }.inject(&:+)
                      "<tr><td>#{file_name}</td>\n#{cells}</tr>\n"
-                   }
-                   .inject(&:+)
+                   }.inject(&:+)
 
         table = "<table>#{header}#{rows}</table>"
         comment = if params[:fold_result]

--- a/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
+++ b/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
@@ -36,7 +36,7 @@ module Fastlane
                    .map { |file_name|
                      cells = devices.map { |device|
                        file_path = "#{screenshot_dir}/#{device}/#{file_name}"
-                       next if !File.exist?(file_path)
+                       next "" unless !File.exist?(file_path)
                        ratio = Helper.calc_aspect_ratio(file_path)
                        is_portrait = ratio >= 1.0
                        size_attr = if params[:image_length] != nil

--- a/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
+++ b/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
@@ -36,7 +36,7 @@ module Fastlane
                    .map { |file_name|
                      cells = devices.map { |device|
                        file_path = "#{screenshot_dir}/#{device}/#{file_name}"
-                       next "" unless File.exist?(file_path)
+                       next "<td></td>" unless File.exist?(file_path)
                        ratio = Helper.calc_aspect_ratio(file_path)
                        is_portrait = ratio >= 1.0
                        size_attr = if params[:image_length] != nil

--- a/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
+++ b/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb
@@ -36,7 +36,7 @@ module Fastlane
                    .map { |file_name|
                      cells = devices.map { |device|
                        file_path = "#{screenshot_dir}/#{device}/#{file_name}"
-                       next "" unless !File.exist?(file_path)
+                       next "" unless File.exist?(file_path)
                        ratio = Helper.calc_aspect_ratio(file_path)
                        is_portrait = ratio >= 1.0
                        size_attr = if params[:image_length] != nil

--- a/lib/fastlane/plugin/screenshot_notifier/version.rb
+++ b/lib/fastlane/plugin/screenshot_notifier/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module ScreenshotNotifier
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
   end
 end


### PR DESCRIPTION
next 構文利用時に nil が配列に含まれてしまい、そのまま連結すると以下のようになるため
空を追加するとともに、デバイスフォルダのチェックも追加しました。

```
bundler: failed to load command: fastlane (/home/circleci/workspace/vendor/bundle/ruby/2.6.0/bin/fastlane)
TypeError: [!] no implicit conversion of nil into String
  /home/circleci/workspace/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-screenshot_notifier-0.1.1/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb:53:in `+'
  /home/circleci/workspace/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-screenshot_notifier-0.1.1/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb:53:in `each'
  /home/circleci/workspace/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-screenshot_notifier-0.1.1/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb:53:in `inject'
  /home/circleci/workspace/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-screenshot_notifier-0.1.1/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb:53:in `block in run'
  /home/circleci/workspace/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-screenshot_notifier-0.1.1/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb:31:in `map'
  /home/circleci/workspace/vendor/bundle/ruby/2.6.0/gems/fastlane-plugin-screenshot_notifier-0.1.1/lib/fastlane/plugin/screenshot_notifier/actions/screenshot_notifier_action.rb:31:in `run'
 
```